### PR TITLE
fix: prepare script on node_modules deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Fetches the registry tarballs and compare files between a spec `a` and spec `b`.
 - `diffSrcPrefix <String>`: Prefix to be used in the filenames from `a`. Defaults to `a/`.
 - `diffDstPrefix <String>`: Prefix to be used in the filenames from `b`. Defaults to `b/`.
 - `diffText <Boolean>`: Should treat all files as text and try to print diff for binary files. Defaults to `false`.
-- ...`cache`, `registry` and other common options accepted by [pacote](https://github.com/npm/pacote#options)
+- ...`cache`, `registry`, `where` and other common options accepted by [pacote](https://github.com/npm/pacote#options)
 
 Returns a `Promise` that fullfils with a `String` containing the resulting patch diffs.
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const pacote = require('pacote')
 
 const formatDiff = require('./lib/format-diff.js')
+const getTarball = require('./lib/tarball.js')
 const untar = require('./lib/untar.js')
 
 const argsError = () =>
@@ -25,8 +26,8 @@ const diff = async (specs, opts = {}) => {
 
   // fetches tarball using pacote
   const [a, b] = await Promise.all([
-    pacote.tarball(aManifest._resolved, opts),
-    pacote.tarball(bManifest._resolved, opts),
+    getTarball(aManifest, opts),
+    getTarball(bManifest, opts),
   ])
 
   // read all files

--- a/lib/tarball.js
+++ b/lib/tarball.js
@@ -1,0 +1,33 @@
+const { relative } = require('path')
+
+const npa = require('npm-package-arg')
+const pkgContents = require('@npmcli/installed-package-contents')
+const pacote = require('pacote')
+const { tarCreateOptions } = pacote.DirFetcher
+const tar = require('tar')
+
+// returns a simplified tarball when reading files from node_modules folder,
+// thus avoiding running the prepare scripts and the extra logic from packlist
+const nodeModulesTarball = (manifest, opts) =>
+  pkgContents({ path: manifest._resolved, depth: 1 })
+    .then(files =>
+      files.map(file => relative(manifest._resolved, file))
+    )
+    .then(files =>
+      tar.c(tarCreateOptions(manifest), files).concat()
+    )
+
+const tarball = (manifest, opts) => {
+  const resolved = manifest._resolved
+  const where = opts.where || process.cwd()
+
+  const fromNodeModules = npa(resolved).type === 'directory'
+    && /node_modules[\\/](@[^\\/]+\/)?[^\\/]+[\\/]?$/.test(relative(where, resolved))
+
+  if (fromNodeModules)
+    return nodeModulesTarball(manifest, opts)
+
+  return pacote.tarball(manifest._resolved, opts)
+}
+
+module.exports = tarball

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "license": "ISC",
       "dependencies": {
         "@npmcli/disparity-colors": "^1.0.1",
+        "@npmcli/installed-package-contents": "^1.0.7",
         "binary-extensions": "^2.2.0",
         "diff": "^5.0.0",
         "minimatch": "^3.0.4",
-        "pacote": "^11.2.3",
+        "npm-package-arg": "^8.1.1",
+        "pacote": "^11.3.0",
         "tar": "^6.1.0"
       },
       "devDependencies": {
@@ -289,14 +291,12 @@
       }
     },
     "node_modules/@npmcli/installed-package-contents": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.5.tgz",
-      "integrity": "sha512-aKIwguaaqb6ViwSOFytniGvLPb9SMCUm39TgM3SfUo7n0TxUMbwoXfpwyvQ4blm10lzbAwTsvjr7QZ85LvTi4A==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.7.tgz",
+      "integrity": "sha512-9rufe0wnJusCQoLpV9ZPKIVP55itrM5BxOXs10DmdbRfgWtHy1LDyskbwRnBghuB0PrF7pNPOqREVtpz4HqzKw==",
       "dependencies": {
         "npm-bundled": "^1.1.1",
-        "npm-normalize-package-bin": "^1.0.1",
-        "read-package-json-fast": "^1.1.1",
-        "readdir-scoped-modules": "^1.1.0"
+        "npm-normalize-package-bin": "^1.0.1"
       },
       "bin": {
         "installed-package-contents": "index.js"
@@ -328,9 +328,9 @@
       }
     },
     "node_modules/@npmcli/node-gyp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.1.tgz",
-      "integrity": "sha512-pBqoKPWmuk9iaEcXlLBVRIA6I1kG9JiICU+sG0NuD6NAR461F+02elHJS4WkQxHW2W5rnsfvP/ClKwmsZ9RaaA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.2.tgz",
+      "integrity": "sha512-yrJUe6reVMpktcvagumoqD9r08fH1iRo01gn1u0zoCApa9lnZGEigVKUd2hzsCId4gdtkZZIVscLhNxMECKgRg=="
     },
     "node_modules/@npmcli/promise-spawn": {
       "version": "1.3.2",
@@ -341,16 +341,16 @@
       }
     },
     "node_modules/@npmcli/run-script": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.1.tgz",
-      "integrity": "sha512-G8c86g9cQHyRINosIcpovzv0BkXQc3urhL1ORf3KTe4TS4UBsg2O4Z2feca/W3pfzdHEJzc83ETBW4aKbb3SaA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.3.tgz",
+      "integrity": "sha512-ELPGWAVU/xyU+A+H3pEPj0QOvYwLTX71RArXcClFzeiyJ/b/McsZ+d0QxpznvfFtZzxGN/gz/1cvlqICR4/suQ==",
       "dependencies": {
-        "@npmcli/node-gyp": "^1.0.0",
-        "@npmcli/promise-spawn": "^1.3.0",
+        "@npmcli/node-gyp": "^1.0.2",
+        "@npmcli/promise-spawn": "^1.3.2",
         "infer-owner": "^1.0.4",
         "node-gyp": "^7.1.0",
         "puka": "^1.0.1",
-        "read-package-json-fast": "^1.1.3"
+        "read-package-json-fast": "^2.0.1"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -571,11 +571,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "node_modules/asn1": {
       "version": "0.2.4",
@@ -1074,14 +1069,6 @@
         }
       }
     },
-    "node_modules/debuglog": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -1140,15 +1127,6 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-      "dependencies": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -1217,9 +1195,9 @@
       }
     },
     "node_modules/env-paths": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "engines": {
         "node": ">=6"
       }
@@ -3355,9 +3333,9 @@
       "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
     },
     "node_modules/npm-package-arg": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.0.tgz",
-      "integrity": "sha512-/ep6QDxBkm9HvOhOg0heitSd7JHA1U7y1qhhlRlteYYAi9Pdb/ZV7FW5aHpkrpM8+P+4p/jjR8zCyKPBMBjSig==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.1.tgz",
+      "integrity": "sha512-CsP95FhWQDwNqiYS+Q0mZ7FAEDytDZAkNxQqea6IaAFJTAY9Lhhqyl0irU/6PMc7BGfUmnsbHcqxJD7XuVM/rg==",
       "dependencies": {
         "hosted-git-info": "^3.0.6",
         "semver": "^7.0.0",
@@ -3733,14 +3711,14 @@
       }
     },
     "node_modules/pacote": {
-      "version": "11.2.3",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-11.2.3.tgz",
-      "integrity": "sha512-Jphxyk1EjGyLzNwa+MkbcQUQeTIqlKcIoPq0t9ekR9ZxsTGjzhRjz/cOoL9PTVkqAW1FH7qBoVbYL4FqQGNNJg==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-11.3.0.tgz",
+      "integrity": "sha512-cygprcGpEVqvDzpuPMkGVXW/ooc2ibpoosuJ4YHcUXozDs9VJP7Vha+41pYppG2MVNis4t1BB8IygIBh7vVr2Q==",
       "dependencies": {
         "@npmcli/git": "^2.0.1",
-        "@npmcli/installed-package-contents": "^1.0.5",
+        "@npmcli/installed-package-contents": "^1.0.6",
         "@npmcli/promise-spawn": "^1.2.0",
-        "@npmcli/run-script": "^1.3.0",
+        "@npmcli/run-script": "^1.8.2",
         "cacache": "^15.0.5",
         "chownr": "^2.0.0",
         "fs-minipass": "^2.1.0",
@@ -3751,10 +3729,10 @@
         "npm-packlist": "^2.1.4",
         "npm-pick-manifest": "^6.0.0",
         "npm-registry-fetch": "^9.0.0",
-        "promise-retry": "^1.1.1",
-        "read-package-json-fast": "^1.1.3",
+        "promise-retry": "^2.0.1",
+        "read-package-json-fast": "^2.0.1",
         "rimraf": "^3.0.2",
-        "ssri": "^8.0.0",
+        "ssri": "^8.0.1",
         "tar": "^6.1.0"
       },
       "bin": {
@@ -3763,6 +3741,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/pacote/node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
     },
     "node_modules/pacote/node_modules/mkdirp": {
       "version": "1.0.4",
@@ -3773,6 +3756,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/pacote/node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pacote/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/pacote/node_modules/rimraf": {
@@ -4014,12 +4017,15 @@
       "dev": true
     },
     "node_modules/read-package-json-fast": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-1.2.1.tgz",
-      "integrity": "sha512-OFbpwnHcv74Oa5YN5WvbOBfLw6yPmPcwvyJJw/tj9cWFBF7juQUDLDSZiOjEcgzfweWeeROOmbPpNN1qm4hcRg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-2.0.2.tgz",
+      "integrity": "sha512-5fyFUyO9B799foVk4n6ylcoAktG/FbE3jwRKxvwaeSrIunaoMc0u81dzXxjeAFKOce7O5KncdfwpGvvs6r5PsQ==",
       "dependencies": {
         "json-parse-even-better-errors": "^2.3.0",
         "npm-normalize-package-bin": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/read-pkg": {
@@ -4061,17 +4067,6 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readdir-scoped-modules": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
-      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
-      "dependencies": {
-        "debuglog": "^1.0.1",
-        "dezalgo": "^1.0.0",
-        "graceful-fs": "^4.1.2",
-        "once": "^1.3.0"
       }
     },
     "node_modules/readdirp": {
@@ -4440,9 +4435,9 @@
       }
     },
     "node_modules/ssri": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
-      "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
       "dependencies": {
         "minipass": "^3.1.1"
       },
@@ -4867,8 +4862,6 @@
     },
     "node_modules/tap/node_modules/@babel/code-frame": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4878,8 +4871,6 @@
     },
     "node_modules/tap/node_modules/@babel/core": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
-      "integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4911,8 +4902,6 @@
     },
     "node_modules/tap/node_modules/@babel/core/node_modules/source-map": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -4922,8 +4911,6 @@
     },
     "node_modules/tap/node_modules/@babel/generator": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
-      "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4935,8 +4922,6 @@
     },
     "node_modules/tap/node_modules/@babel/generator/node_modules/source-map": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -4946,8 +4931,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
-      "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4957,8 +4940,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-builder-react-jsx": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz",
-      "integrity": "sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4969,8 +4950,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-builder-react-jsx-experimental": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.10.5.tgz",
-      "integrity": "sha512-Buewnx6M4ttG+NLkKyt7baQn7ScC/Td+e99G914fRU8fGIUivDDgVIQeDHFa5e4CRSJQt58WpNHhsAZgtzVhsg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4982,8 +4961,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-function-name": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4995,8 +4972,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-get-function-arity": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-      "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5006,8 +4981,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
-      "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5017,8 +4990,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-module-imports": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-      "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5028,8 +4999,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-module-transforms": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
-      "integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5045,8 +5014,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-optimise-call-expression": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-      "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5056,16 +5023,12 @@
     },
     "node_modules/tap/node_modules/@babel/helper-plugin-utils": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-      "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/@babel/helper-replace-supers": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-      "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5078,8 +5041,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-simple-access": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-      "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5090,8 +5051,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-split-export-declaration": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-      "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5101,16 +5060,12 @@
     },
     "node_modules/tap/node_modules/@babel/helper-validator-identifier": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/@babel/helpers": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-      "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5122,8 +5077,6 @@
     },
     "node_modules/tap/node_modules/@babel/highlight": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5135,8 +5088,6 @@
     },
     "node_modules/tap/node_modules/@babel/parser": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
-      "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5149,8 +5100,6 @@
     },
     "node_modules/tap/node_modules/@babel/plugin-proposal-object-rest-spread": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.4.tgz",
-      "integrity": "sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5165,8 +5114,6 @@
     },
     "node_modules/tap/node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz",
-      "integrity": "sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5179,8 +5126,6 @@
     },
     "node_modules/tap/node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5193,8 +5138,6 @@
     },
     "node_modules/tap/node_modules/@babel/plugin-transform-destructuring": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
-      "integrity": "sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5207,8 +5150,6 @@
     },
     "node_modules/tap/node_modules/@babel/plugin-transform-parameters": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
-      "integrity": "sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5222,8 +5163,6 @@
     },
     "node_modules/tap/node_modules/@babel/plugin-transform-react-jsx": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz",
-      "integrity": "sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5239,8 +5178,6 @@
     },
     "node_modules/tap/node_modules/@babel/template": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-      "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5252,8 +5189,6 @@
     },
     "node_modules/tap/node_modules/@babel/traverse": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
-      "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5271,8 +5206,6 @@
     },
     "node_modules/tap/node_modules/@babel/types": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
-      "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5284,24 +5217,18 @@
     },
     "node_modules/tap/node_modules/@types/color-name": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/@types/prop-types": {
       "version": "15.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/@types/react": {
       "version": "16.9.43",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.43.tgz",
-      "integrity": "sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5312,16 +5239,12 @@
     },
     "node_modules/tap/node_modules/@types/yoga-layout": {
       "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz",
-      "integrity": "sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/ansi-escapes": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5337,8 +5260,6 @@
     },
     "node_modules/tap/node_modules/ansi-regex": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5348,8 +5269,6 @@
     },
     "node_modules/tap/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5362,16 +5281,12 @@
     },
     "node_modules/tap/node_modules/ansicolors": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/arrify": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5381,8 +5296,6 @@
     },
     "node_modules/tap/node_modules/astral-regex": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5392,8 +5305,6 @@
     },
     "node_modules/tap/node_modules/auto-bind": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
-      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5406,8 +5317,6 @@
     },
     "node_modules/tap/node_modules/caller-callsite": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5420,8 +5329,6 @@
     },
     "node_modules/tap/node_modules/caller-path": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5434,8 +5341,6 @@
     },
     "node_modules/tap/node_modules/callsites": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5445,8 +5350,6 @@
     },
     "node_modules/tap/node_modules/cardinal": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-      "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5460,8 +5363,6 @@
     },
     "node_modules/tap/node_modules/chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5476,16 +5377,12 @@
     },
     "node_modules/tap/node_modules/ci-info": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/cli-cursor": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5498,8 +5395,6 @@
     },
     "node_modules/tap/node_modules/cli-truncate": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5516,8 +5411,6 @@
     },
     "node_modules/tap/node_modules/color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5527,16 +5420,12 @@
     },
     "node_modules/tap/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/convert-source-map": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5546,24 +5435,18 @@
     },
     "node_modules/tap/node_modules/convert-source-map/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/csstype": {
       "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.11.tgz",
-      "integrity": "sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/debug": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5582,16 +5465,12 @@
     },
     "node_modules/tap/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5601,8 +5480,6 @@
     },
     "node_modules/tap/node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -5616,16 +5493,12 @@
     },
     "node_modules/tap/node_modules/events-to-array": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
-      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/gensync": {
       "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5635,8 +5508,6 @@
     },
     "node_modules/tap/node_modules/globals": {
       "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5646,8 +5517,6 @@
     },
     "node_modules/tap/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5657,8 +5526,6 @@
     },
     "node_modules/tap/node_modules/import-jsx": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/import-jsx/-/import-jsx-3.1.0.tgz",
-      "integrity": "sha512-lTuMdQ/mRXC+xQSGPDvAg1VkODlX78j5hZv2tneJ+zuo7GH/XhUF/YVKoeF382a4jO4GYw9jgganbMhEcxwb0g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5676,8 +5543,6 @@
     },
     "node_modules/tap/node_modules/ink": {
       "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/ink/-/ink-2.7.1.tgz",
-      "integrity": "sha512-s7lJuQDJEdjqtaIWhp3KYHl6WV3J04U9zoQ6wVc+Xoa06XM27SXUY57qC5DO46xkF0CfgXMKkKNcgvSu/SAEpA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5716,8 +5581,6 @@
     },
     "node_modules/tap/node_modules/ink/node_modules/ansi-styles": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5734,8 +5597,6 @@
     },
     "node_modules/tap/node_modules/ink/node_modules/chalk": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5749,8 +5610,6 @@
     },
     "node_modules/tap/node_modules/ink/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5763,16 +5622,12 @@
     },
     "node_modules/tap/node_modules/ink/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/ink/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5782,8 +5637,6 @@
     },
     "node_modules/tap/node_modules/ink/node_modules/supports-color": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5796,8 +5649,6 @@
     },
     "node_modules/tap/node_modules/is-ci": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5810,8 +5661,6 @@
     },
     "node_modules/tap/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5821,16 +5670,12 @@
     },
     "node_modules/tap/node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/jsesc": {
       "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5843,8 +5688,6 @@
     },
     "node_modules/tap/node_modules/json5": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5860,24 +5703,18 @@
     },
     "node_modules/tap/node_modules/lodash": {
       "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/lodash.throttle": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/log-update": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-3.4.0.tgz",
-      "integrity": "sha512-ILKe88NeMt4gmDvk/eb615U/IVn7K9KWGkoYbdatQ69Z65nj1ZzjM6fHXfcs0Uge+e+EGnMW7DY4T9yko8vWFg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5895,8 +5732,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/ansi-escapes": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5906,8 +5741,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/ansi-regex": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5917,8 +5750,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/cli-cursor": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5931,16 +5762,12 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/emoji-regex": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/log-update/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5950,8 +5777,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/mimic-fn": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5961,8 +5786,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/onetime": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5975,8 +5798,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/restore-cursor": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5990,8 +5811,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/string-width": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6006,8 +5825,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6020,8 +5837,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6036,8 +5851,6 @@
     },
     "node_modules/tap/node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6050,8 +5863,6 @@
     },
     "node_modules/tap/node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6061,16 +5872,12 @@
     },
     "node_modules/tap/node_modules/minimist": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/minipass": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6083,24 +5890,18 @@
     },
     "node_modules/tap/node_modules/minipass/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6110,8 +5911,6 @@
     },
     "node_modules/tap/node_modules/onetime": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6124,16 +5923,12 @@
     },
     "node_modules/tap/node_modules/path-parse": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/prop-types": {
       "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6145,8 +5940,6 @@
     },
     "node_modules/tap/node_modules/punycode": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6156,16 +5949,12 @@
     },
     "node_modules/tap/node_modules/react-is": {
       "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/react-reconciler": {
       "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.24.0.tgz",
-      "integrity": "sha512-gAGnwWkf+NOTig9oOowqid9O0HjTDC+XVGBCAmJYYJ2A2cN/O4gDdIuuUQjv8A4v6GDwVfJkagpBBLW5OW9HSw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6184,8 +5973,6 @@
     },
     "node_modules/tap/node_modules/redeyed": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-      "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6195,8 +5982,6 @@
     },
     "node_modules/tap/node_modules/resolve": {
       "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6209,8 +5994,6 @@
     },
     "node_modules/tap/node_modules/resolve-from": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6220,8 +6003,6 @@
     },
     "node_modules/tap/node_modules/restore-cursor": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6247,8 +6028,6 @@
     },
     "node_modules/tap/node_modules/scheduler": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-      "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6259,8 +6038,6 @@
     },
     "node_modules/tap/node_modules/semver": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6270,16 +6047,12 @@
     },
     "node_modules/tap/node_modules/signal-exit": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/slice-ansi": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6294,8 +6067,6 @@
     },
     "node_modules/tap/node_modules/slice-ansi/node_modules/ansi-styles": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6312,8 +6083,6 @@
     },
     "node_modules/tap/node_modules/slice-ansi/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6326,16 +6095,12 @@
     },
     "node_modules/tap/node_modules/slice-ansi/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/string-length": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
-      "integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6349,8 +6114,6 @@
     },
     "node_modules/tap/node_modules/string-length/node_modules/ansi-regex": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6360,8 +6123,6 @@
     },
     "node_modules/tap/node_modules/string-length/node_modules/astral-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6371,8 +6132,6 @@
     },
     "node_modules/tap/node_modules/string-length/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6385,8 +6144,6 @@
     },
     "node_modules/tap/node_modules/string-width": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6401,8 +6158,6 @@
     },
     "node_modules/tap/node_modules/strip-ansi": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6415,8 +6170,6 @@
     },
     "node_modules/tap/node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6429,8 +6182,6 @@
     },
     "node_modules/tap/node_modules/tap-parser": {
       "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-10.0.1.tgz",
-      "integrity": "sha512-qdT15H0DoJIi7zOqVXDn9X0gSM68JjNy1w3VemwTJlDnETjbi6SutnqmBfjDJAwkFS79NJ97gZKqie00ZCGmzg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6448,8 +6199,6 @@
     },
     "node_modules/tap/node_modules/tap-yaml": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-1.0.0.tgz",
-      "integrity": "sha512-Rxbx4EnrWkYk0/ztcm5u3/VznbyFJpyXO12dDBHKWiDVxy7O2Qw6MRrwO5H6Ww0U5YhRY/4C/VzWmFPhBQc4qQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6459,8 +6208,6 @@
     },
     "node_modules/tap/node_modules/to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6470,8 +6217,6 @@
     },
     "node_modules/tap/node_modules/treport": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/treport/-/treport-1.0.2.tgz",
-      "integrity": "sha512-QCAbFtzIjQN+9k+alo8e6oo8j0eSLsttdahAgNLoC3U36rls8XRy/R11QOhHmPz7CDcB2ar29eLe4OFJoPnsPA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6491,8 +6236,6 @@
     },
     "node_modules/tap/node_modules/treport/node_modules/ansi-styles": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6509,8 +6252,6 @@
     },
     "node_modules/tap/node_modules/treport/node_modules/chalk": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6524,8 +6265,6 @@
     },
     "node_modules/tap/node_modules/treport/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6538,16 +6277,12 @@
     },
     "node_modules/tap/node_modules/treport/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/treport/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6557,8 +6292,6 @@
     },
     "node_modules/tap/node_modules/treport/node_modules/supports-color": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6571,8 +6304,6 @@
     },
     "node_modules/tap/node_modules/type-fest": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-      "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
       "dev": true,
       "inBundle": true,
       "license": "(MIT OR CC0-1.0)",
@@ -6585,8 +6316,6 @@
     },
     "node_modules/tap/node_modules/unicode-length": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-2.0.2.tgz",
-      "integrity": "sha512-Ph/j1VbS3/r77nhoY2WU0GWGjVYOHL3xpKp0y/Eq2e5r0mT/6b649vm7KFO6RdAdrZkYLdxphYVgvODxPB+Ebg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6597,8 +6326,6 @@
     },
     "node_modules/tap/node_modules/unicode-length/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6608,8 +6335,6 @@
     },
     "node_modules/tap/node_modules/unicode-length/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6622,8 +6347,6 @@
     },
     "node_modules/tap/node_modules/widest-line": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6636,8 +6359,6 @@
     },
     "node_modules/tap/node_modules/wrap-ansi": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6652,8 +6373,6 @@
     },
     "node_modules/tap/node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6670,8 +6389,6 @@
     },
     "node_modules/tap/node_modules/wrap-ansi/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6684,16 +6401,12 @@
     },
     "node_modules/tap/node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/yaml": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6703,8 +6416,6 @@
     },
     "node_modules/tap/node_modules/yoga-layout-prebuilt": {
       "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.9.6.tgz",
-      "integrity": "sha512-Wursw6uqLXLMjBAO4SEShuzj8+EJXhCF71/rJ7YndHTkRAYSU0GY3OghRqfAk9HPUAAFMuqp3U1Wl+01vmGRQQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7740,14 +7451,12 @@
       }
     },
     "@npmcli/installed-package-contents": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.5.tgz",
-      "integrity": "sha512-aKIwguaaqb6ViwSOFytniGvLPb9SMCUm39TgM3SfUo7n0TxUMbwoXfpwyvQ4blm10lzbAwTsvjr7QZ85LvTi4A==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.7.tgz",
+      "integrity": "sha512-9rufe0wnJusCQoLpV9ZPKIVP55itrM5BxOXs10DmdbRfgWtHy1LDyskbwRnBghuB0PrF7pNPOqREVtpz4HqzKw==",
       "requires": {
         "npm-bundled": "^1.1.1",
-        "npm-normalize-package-bin": "^1.0.1",
-        "read-package-json-fast": "^1.1.1",
-        "readdir-scoped-modules": "^1.1.0"
+        "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "@npmcli/move-file": {
@@ -7766,9 +7475,9 @@
       }
     },
     "@npmcli/node-gyp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.1.tgz",
-      "integrity": "sha512-pBqoKPWmuk9iaEcXlLBVRIA6I1kG9JiICU+sG0NuD6NAR461F+02elHJS4WkQxHW2W5rnsfvP/ClKwmsZ9RaaA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.2.tgz",
+      "integrity": "sha512-yrJUe6reVMpktcvagumoqD9r08fH1iRo01gn1u0zoCApa9lnZGEigVKUd2hzsCId4gdtkZZIVscLhNxMECKgRg=="
     },
     "@npmcli/promise-spawn": {
       "version": "1.3.2",
@@ -7779,16 +7488,16 @@
       }
     },
     "@npmcli/run-script": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.1.tgz",
-      "integrity": "sha512-G8c86g9cQHyRINosIcpovzv0BkXQc3urhL1ORf3KTe4TS4UBsg2O4Z2feca/W3pfzdHEJzc83ETBW4aKbb3SaA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.3.tgz",
+      "integrity": "sha512-ELPGWAVU/xyU+A+H3pEPj0QOvYwLTX71RArXcClFzeiyJ/b/McsZ+d0QxpznvfFtZzxGN/gz/1cvlqICR4/suQ==",
       "requires": {
-        "@npmcli/node-gyp": "^1.0.0",
-        "@npmcli/promise-spawn": "^1.3.0",
+        "@npmcli/node-gyp": "^1.0.2",
+        "@npmcli/promise-spawn": "^1.3.2",
         "infer-owner": "^1.0.4",
         "node-gyp": "^7.1.0",
         "puka": "^1.0.1",
-        "read-package-json-fast": "^1.1.3"
+        "read-package-json-fast": "^2.0.1"
       }
     },
     "@tootallnate/once": {
@@ -7955,11 +7664,6 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.18.0-next.1"
       }
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.4",
@@ -8357,11 +8061,6 @@
         "ms": "2.1.2"
       }
     },
-    "debuglog": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
-    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -8406,15 +8105,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-    },
-    "dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-      "requires": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
     },
     "diff": {
       "version": "5.0.0",
@@ -8470,9 +8160,9 @@
       }
     },
     "env-paths": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
     },
     "err-code": {
       "version": "1.1.2",
@@ -10135,9 +9825,9 @@
       "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
     },
     "npm-package-arg": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.0.tgz",
-      "integrity": "sha512-/ep6QDxBkm9HvOhOg0heitSd7JHA1U7y1qhhlRlteYYAi9Pdb/ZV7FW5aHpkrpM8+P+4p/jjR8zCyKPBMBjSig==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.1.tgz",
+      "integrity": "sha512-CsP95FhWQDwNqiYS+Q0mZ7FAEDytDZAkNxQqea6IaAFJTAY9Lhhqyl0irU/6PMc7BGfUmnsbHcqxJD7XuVM/rg==",
       "requires": {
         "hosted-git-info": "^3.0.6",
         "semver": "^7.0.0",
@@ -10424,14 +10114,14 @@
       }
     },
     "pacote": {
-      "version": "11.2.3",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-11.2.3.tgz",
-      "integrity": "sha512-Jphxyk1EjGyLzNwa+MkbcQUQeTIqlKcIoPq0t9ekR9ZxsTGjzhRjz/cOoL9PTVkqAW1FH7qBoVbYL4FqQGNNJg==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-11.3.0.tgz",
+      "integrity": "sha512-cygprcGpEVqvDzpuPMkGVXW/ooc2ibpoosuJ4YHcUXozDs9VJP7Vha+41pYppG2MVNis4t1BB8IygIBh7vVr2Q==",
       "requires": {
         "@npmcli/git": "^2.0.1",
-        "@npmcli/installed-package-contents": "^1.0.5",
+        "@npmcli/installed-package-contents": "^1.0.6",
         "@npmcli/promise-spawn": "^1.2.0",
-        "@npmcli/run-script": "^1.3.0",
+        "@npmcli/run-script": "^1.8.2",
         "cacache": "^15.0.5",
         "chownr": "^2.0.0",
         "fs-minipass": "^2.1.0",
@@ -10442,17 +10132,36 @@
         "npm-packlist": "^2.1.4",
         "npm-pick-manifest": "^6.0.0",
         "npm-registry-fetch": "^9.0.0",
-        "promise-retry": "^1.1.1",
-        "read-package-json-fast": "^1.1.3",
+        "promise-retry": "^2.0.1",
+        "read-package-json-fast": "^2.0.1",
         "rimraf": "^3.0.2",
-        "ssri": "^8.0.0",
+        "ssri": "^8.0.1",
         "tar": "^6.1.0"
       },
       "dependencies": {
+        "err-code": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+          "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        },
+        "promise-retry": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+          "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+          "requires": {
+            "err-code": "^2.0.2",
+            "retry": "^0.12.0"
+          }
+        },
+        "retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
         },
         "rimraf": {
           "version": "3.0.2",
@@ -10635,9 +10344,9 @@
       "dev": true
     },
     "read-package-json-fast": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-1.2.1.tgz",
-      "integrity": "sha512-OFbpwnHcv74Oa5YN5WvbOBfLw6yPmPcwvyJJw/tj9cWFBF7juQUDLDSZiOjEcgzfweWeeROOmbPpNN1qm4hcRg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-2.0.2.tgz",
+      "integrity": "sha512-5fyFUyO9B799foVk4n6ylcoAktG/FbE3jwRKxvwaeSrIunaoMc0u81dzXxjeAFKOce7O5KncdfwpGvvs6r5PsQ==",
       "requires": {
         "json-parse-even-better-errors": "^2.3.0",
         "npm-normalize-package-bin": "^1.0.1"
@@ -10676,17 +10385,6 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
-      }
-    },
-    "readdir-scoped-modules": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
-      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
-      "requires": {
-        "debuglog": "^1.0.1",
-        "dezalgo": "^1.0.0",
-        "graceful-fs": "^4.1.2",
-        "once": "^1.3.0"
       }
     },
     "readdirp": {
@@ -10978,9 +10676,9 @@
       }
     },
     "ssri": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
-      "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
       "requires": {
         "minipass": "^3.1.1"
       }
@@ -11188,8 +10886,6 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11198,8 +10894,6 @@
         },
         "@babel/core": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
-          "integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11223,8 +10917,6 @@
           "dependencies": {
             "source-map": {
               "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
               "bundled": true,
               "dev": true
             }
@@ -11232,8 +10924,6 @@
         },
         "@babel/generator": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
-          "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11244,8 +10934,6 @@
           "dependencies": {
             "source-map": {
               "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
               "bundled": true,
               "dev": true
             }
@@ -11253,8 +10941,6 @@
         },
         "@babel/helper-annotate-as-pure": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
-          "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11263,8 +10949,6 @@
         },
         "@babel/helper-builder-react-jsx": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz",
-          "integrity": "sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11274,8 +10958,6 @@
         },
         "@babel/helper-builder-react-jsx-experimental": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.10.5.tgz",
-          "integrity": "sha512-Buewnx6M4ttG+NLkKyt7baQn7ScC/Td+e99G914fRU8fGIUivDDgVIQeDHFa5e4CRSJQt58WpNHhsAZgtzVhsg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11286,8 +10968,6 @@
         },
         "@babel/helper-function-name": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11298,8 +10978,6 @@
         },
         "@babel/helper-get-function-arity": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11308,8 +10986,6 @@
         },
         "@babel/helper-member-expression-to-functions": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
-          "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11318,8 +10994,6 @@
         },
         "@babel/helper-module-imports": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-          "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11328,8 +11002,6 @@
         },
         "@babel/helper-module-transforms": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
-          "integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11344,8 +11016,6 @@
         },
         "@babel/helper-optimise-call-expression": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-          "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11354,15 +11024,11 @@
         },
         "@babel/helper-plugin-utils": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
           "bundled": true,
           "dev": true
         },
         "@babel/helper-replace-supers": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-          "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11374,8 +11040,6 @@
         },
         "@babel/helper-simple-access": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-          "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11385,8 +11049,6 @@
         },
         "@babel/helper-split-export-declaration": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-          "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11395,15 +11057,11 @@
         },
         "@babel/helper-validator-identifier": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
           "bundled": true,
           "dev": true
         },
         "@babel/helpers": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-          "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11414,8 +11072,6 @@
         },
         "@babel/highlight": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11426,15 +11082,11 @@
         },
         "@babel/parser": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
-          "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
           "bundled": true,
           "dev": true
         },
         "@babel/plugin-proposal-object-rest-spread": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.4.tgz",
-          "integrity": "sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11445,8 +11097,6 @@
         },
         "@babel/plugin-syntax-jsx": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz",
-          "integrity": "sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11455,8 +11105,6 @@
         },
         "@babel/plugin-syntax-object-rest-spread": {
           "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-          "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11465,8 +11113,6 @@
         },
         "@babel/plugin-transform-destructuring": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
-          "integrity": "sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11475,8 +11121,6 @@
         },
         "@babel/plugin-transform-parameters": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
-          "integrity": "sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11486,8 +11130,6 @@
         },
         "@babel/plugin-transform-react-jsx": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz",
-          "integrity": "sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11499,8 +11141,6 @@
         },
         "@babel/template": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-          "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11511,8 +11151,6 @@
         },
         "@babel/traverse": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
-          "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11529,8 +11167,6 @@
         },
         "@babel/types": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
-          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11541,22 +11177,16 @@
         },
         "@types/color-name": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-          "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
           "bundled": true,
           "dev": true
         },
         "@types/prop-types": {
           "version": "15.7.3",
-          "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-          "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
           "bundled": true,
           "dev": true
         },
         "@types/react": {
           "version": "16.9.43",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.43.tgz",
-          "integrity": "sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11566,15 +11196,11 @@
         },
         "@types/yoga-layout": {
           "version": "1.9.2",
-          "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz",
-          "integrity": "sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==",
           "bundled": true,
           "dev": true
         },
         "ansi-escapes": {
           "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11583,15 +11209,11 @@
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "bundled": true,
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11600,36 +11222,26 @@
         },
         "ansicolors": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
           "bundled": true,
           "dev": true
         },
         "arrify": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
           "bundled": true,
           "dev": true
         },
         "astral-regex": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
           "bundled": true,
           "dev": true
         },
         "auto-bind": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
-          "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
           "bundled": true,
           "dev": true
         },
         "caller-callsite": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-          "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11638,8 +11250,6 @@
         },
         "caller-path": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-          "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11648,15 +11258,11 @@
         },
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "bundled": true,
           "dev": true
         },
         "cardinal": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-          "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11666,8 +11272,6 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11678,15 +11282,11 @@
         },
         "ci-info": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
           "bundled": true,
           "dev": true
         },
         "cli-cursor": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11695,8 +11295,6 @@
         },
         "cli-truncate": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-          "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11706,8 +11304,6 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11716,15 +11312,11 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "bundled": true,
           "dev": true
         },
         "convert-source-map": {
           "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-          "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11733,8 +11325,6 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "bundled": true,
               "dev": true
             }
@@ -11742,15 +11332,11 @@
         },
         "csstype": {
           "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.11.tgz",
-          "integrity": "sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==",
           "bundled": true,
           "dev": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11765,57 +11351,41 @@
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "bundled": true,
           "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "bundled": true,
           "dev": true
         },
         "esprima": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
           "bundled": true,
           "dev": true
         },
         "events-to-array": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
-          "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
           "bundled": true,
           "dev": true
         },
         "gensync": {
           "version": "1.0.0-beta.1",
-          "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-          "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
           "bundled": true,
           "dev": true
         },
         "globals": {
           "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "bundled": true,
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "bundled": true,
           "dev": true
         },
         "import-jsx": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/import-jsx/-/import-jsx-3.1.0.tgz",
-          "integrity": "sha512-lTuMdQ/mRXC+xQSGPDvAg1VkODlX78j5hZv2tneJ+zuo7GH/XhUF/YVKoeF382a4jO4GYw9jgganbMhEcxwb0g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11829,8 +11399,6 @@
         },
         "ink": {
           "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/ink/-/ink-2.7.1.tgz",
-          "integrity": "sha512-s7lJuQDJEdjqtaIWhp3KYHl6WV3J04U9zoQ6wVc+Xoa06XM27SXUY57qC5DO46xkF0CfgXMKkKNcgvSu/SAEpA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11856,8 +11424,6 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -11867,8 +11433,6 @@
             },
             "chalk": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -11878,8 +11442,6 @@
             },
             "color-convert": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -11888,22 +11450,16 @@
             },
             "color-name": {
               "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
               "bundled": true,
               "dev": true
             },
             "has-flag": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
               "bundled": true,
               "dev": true
             },
             "supports-color": {
               "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -11914,8 +11470,6 @@
         },
         "is-ci": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11924,29 +11478,21 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "bundled": true,
           "dev": true
         },
         "js-tokens": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
           "bundled": true,
           "dev": true
         },
         "jsesc": {
           "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
           "bundled": true,
           "dev": true
         },
         "json5": {
           "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11955,22 +11501,16 @@
         },
         "lodash": {
           "version": "4.17.19",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
           "bundled": true,
           "dev": true
         },
         "lodash.throttle": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-          "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
           "bundled": true,
           "dev": true
         },
         "log-update": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/log-update/-/log-update-3.4.0.tgz",
-          "integrity": "sha512-ILKe88NeMt4gmDvk/eb615U/IVn7K9KWGkoYbdatQ69Z65nj1ZzjM6fHXfcs0Uge+e+EGnMW7DY4T9yko8vWFg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -11981,22 +11521,16 @@
           "dependencies": {
             "ansi-escapes": {
               "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-              "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
               "bundled": true,
               "dev": true
             },
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "bundled": true,
               "dev": true
             },
             "cli-cursor": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-              "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12005,29 +11539,21 @@
             },
             "emoji-regex": {
               "version": "7.0.3",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-              "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
               "bundled": true,
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "bundled": true,
               "dev": true
             },
             "mimic-fn": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-              "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
               "bundled": true,
               "dev": true
             },
             "onetime": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-              "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12036,8 +11562,6 @@
             },
             "restore-cursor": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-              "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12047,8 +11571,6 @@
             },
             "string-width": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12059,8 +11581,6 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12069,8 +11589,6 @@
             },
             "wrap-ansi": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-              "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12083,8 +11601,6 @@
         },
         "loose-envify": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12093,22 +11609,16 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "bundled": true,
           "dev": true
         },
         "minimist": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "bundled": true,
           "dev": true
         },
         "minipass": {
           "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12117,8 +11627,6 @@
           "dependencies": {
             "yallist": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
               "bundled": true,
               "dev": true
             }
@@ -12126,22 +11634,16 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "bundled": true,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "bundled": true,
           "dev": true
         },
         "onetime": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12150,15 +11652,11 @@
         },
         "path-parse": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
           "bundled": true,
           "dev": true
         },
         "prop-types": {
           "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12169,22 +11667,16 @@
         },
         "punycode": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
           "bundled": true,
           "dev": true
         },
         "react-is": {
           "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
           "bundled": true,
           "dev": true
         },
         "react-reconciler": {
           "version": "0.24.0",
-          "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.24.0.tgz",
-          "integrity": "sha512-gAGnwWkf+NOTig9oOowqid9O0HjTDC+XVGBCAmJYYJ2A2cN/O4gDdIuuUQjv8A4v6GDwVfJkagpBBLW5OW9HSw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12196,8 +11688,6 @@
         },
         "redeyed": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-          "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12206,8 +11696,6 @@
         },
         "resolve": {
           "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12216,15 +11704,11 @@
         },
         "resolve-from": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "bundled": true,
           "dev": true
         },
         "restore-cursor": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12243,8 +11727,6 @@
         },
         "scheduler": {
           "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-          "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12254,22 +11736,16 @@
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "bundled": true,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-          "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
           "bundled": true,
           "dev": true
         },
         "slice-ansi": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-          "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12280,8 +11756,6 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12291,8 +11765,6 @@
             },
             "color-convert": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12301,8 +11773,6 @@
             },
             "color-name": {
               "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
               "bundled": true,
               "dev": true
             }
@@ -12310,8 +11780,6 @@
         },
         "string-length": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
-          "integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12321,22 +11789,16 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "bundled": true,
               "dev": true
             },
             "astral-regex": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-              "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
               "bundled": true,
               "dev": true
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12347,8 +11809,6 @@
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12359,8 +11819,6 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12369,8 +11827,6 @@
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12379,8 +11835,6 @@
         },
         "tap-parser": {
           "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-10.0.1.tgz",
-          "integrity": "sha512-qdT15H0DoJIi7zOqVXDn9X0gSM68JjNy1w3VemwTJlDnETjbi6SutnqmBfjDJAwkFS79NJ97gZKqie00ZCGmzg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12391,8 +11845,6 @@
         },
         "tap-yaml": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-1.0.0.tgz",
-          "integrity": "sha512-Rxbx4EnrWkYk0/ztcm5u3/VznbyFJpyXO12dDBHKWiDVxy7O2Qw6MRrwO5H6Ww0U5YhRY/4C/VzWmFPhBQc4qQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12401,15 +11853,11 @@
         },
         "to-fast-properties": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "bundled": true,
           "dev": true
         },
         "treport": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/treport/-/treport-1.0.2.tgz",
-          "integrity": "sha512-QCAbFtzIjQN+9k+alo8e6oo8j0eSLsttdahAgNLoC3U36rls8XRy/R11QOhHmPz7CDcB2ar29eLe4OFJoPnsPA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12425,8 +11873,6 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12436,8 +11882,6 @@
             },
             "chalk": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12447,8 +11891,6 @@
             },
             "color-convert": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12457,22 +11899,16 @@
             },
             "color-name": {
               "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
               "bundled": true,
               "dev": true
             },
             "has-flag": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
               "bundled": true,
               "dev": true
             },
             "supports-color": {
               "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12483,15 +11919,11 @@
         },
         "type-fest": {
           "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
           "bundled": true,
           "dev": true
         },
         "unicode-length": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-2.0.2.tgz",
-          "integrity": "sha512-Ph/j1VbS3/r77nhoY2WU0GWGjVYOHL3xpKp0y/Eq2e5r0mT/6b649vm7KFO6RdAdrZkYLdxphYVgvODxPB+Ebg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12501,15 +11933,11 @@
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "bundled": true,
               "dev": true
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12520,8 +11948,6 @@
         },
         "widest-line": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-          "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12530,8 +11956,6 @@
         },
         "wrap-ansi": {
           "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -12542,8 +11966,6 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12553,8 +11975,6 @@
             },
             "color-convert": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -12563,8 +11983,6 @@
             },
             "color-name": {
               "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
               "bundled": true,
               "dev": true
             }
@@ -12572,15 +11990,11 @@
         },
         "yaml": {
           "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-          "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
           "bundled": true,
           "dev": true
         },
         "yoga-layout-prebuilt": {
           "version": "1.9.6",
-          "resolved": "https://registry.npmjs.org/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.9.6.tgz",
-          "integrity": "sha512-Wursw6uqLXLMjBAO4SEShuzj8+EJXhCF71/rJ7YndHTkRAYSU0GY3OghRqfAk9HPUAAFMuqp3U1Wl+01vmGRQQ==",
           "bundled": true,
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -55,10 +55,12 @@
   },
   "dependencies": {
     "@npmcli/disparity-colors": "^1.0.1",
+    "@npmcli/installed-package-contents": "^1.0.7",
     "binary-extensions": "^2.2.0",
     "diff": "^5.0.0",
     "minimatch": "^3.0.4",
-    "pacote": "^11.2.3",
+    "npm-package-arg": "^8.1.1",
+    "pacote": "^11.3.0",
     "tar": "^6.1.0"
   }
 }

--- a/tap-snapshots/test-index.js-TAP.test.js
+++ b/tap-snapshots/test-index.js-TAP.test.js
@@ -25,3 +25,91 @@ index v1.0.0..v2.0.0 100644
 +  "version": "2.0.0"
  }
 `
+
+exports[`test/index.js TAP folder in node_modules nested, absolute path > should output expected diff 1`] = `
+diff --git a/package.json b/package.json
+index v2.0.0..v2.0.1 100644
+--- a/package.json
++++ b/package.json
+@@ -1,6 +1,6 @@
+ {
+   "name": "b",
+-  "version": "2.0.0",
++  "version": "2.0.1",
+   "scripts": {
+     "prepare": "node prepare.js"
+   }
+diff --git a/prepare.js b/prepare.js
+index v2.0.0..v2.0.1 100644
+--- a/prepare.js
++++ b/prepare.js
+@@ -1,1 +0,0 @@
+-throw new Error("ERR")
+/ No newline at end of file
+`
+
+exports[`test/index.js TAP folder in node_modules nested, relative path > should output expected diff 1`] = `
+diff --git a/package.json b/package.json
+index v2.0.0..v2.0.1 100644
+--- a/package.json
++++ b/package.json
+@@ -1,6 +1,6 @@
+ {
+   "name": "b",
+-  "version": "2.0.0",
++  "version": "2.0.1",
+   "scripts": {
+     "prepare": "node prepare.js"
+   }
+diff --git a/prepare.js b/prepare.js
+index v2.0.0..v2.0.1 100644
+--- a/prepare.js
++++ b/prepare.js
+@@ -1,1 +0,0 @@
+-throw new Error("ERR")
+/ No newline at end of file
+`
+
+exports[`test/index.js TAP folder in node_modules top-level, absolute path > should output expected diff 1`] = `
+diff --git a/package.json b/package.json
+index v1.0.0..v1.0.1 100644
+--- a/package.json
++++ b/package.json
+@@ -1,6 +1,6 @@
+ {
+   "name": "a",
+-  "version": "1.0.0",
++  "version": "1.0.1",
+   "scripts": {
+     "prepare": "node prepare.js"
+   }
+diff --git a/prepare.js b/prepare.js
+index v1.0.0..v1.0.1 100644
+--- a/prepare.js
++++ b/prepare.js
+@@ -1,1 +0,0 @@
+-throw new Error("ERR")
+/ No newline at end of file
+`
+
+exports[`test/index.js TAP folder in node_modules top-level, relative path > should output expected diff 1`] = `
+diff --git a/package.json b/package.json
+index v1.0.0..v1.0.1 100644
+--- a/package.json
++++ b/package.json
+@@ -1,6 +1,6 @@
+ {
+   "name": "a",
+-  "version": "1.0.0",
++  "version": "1.0.1",
+   "scripts": {
+     "prepare": "node prepare.js"
+   }
+diff --git a/prepare.js b/prepare.js
+index v1.0.0..v1.0.1 100644
+--- a/prepare.js
++++ b/prepare.js
+@@ -1,1 +0,0 @@
+-throw new Error("ERR")
+/ No newline at end of file
+`

--- a/test/index.js
+++ b/test/index.js
@@ -4,14 +4,12 @@ const t = require('tap')
 
 const diff = require('../index.js')
 
-const redactCwd = (path) => {
-  const normalizePath = p => p
-    .replace(/\\+/g, '/')
-    .replace(/\r\n/g, '\n')
-  return normalizePath(path)
-}
+const normalizePath = p => p
+  .replace(/\\+/g, '/')
+  .replace(/\r\n/g, '\n')
 
-t.cleanSnapshot = (str) => redactCwd(str)
+t.cleanSnapshot = (str) => normalizePath(str)
+  .replace(normalizePath(process.execPath), 'node')
 
 const json = (obj) => `${JSON.stringify(obj, null, 2)}\n`
 
@@ -54,4 +52,96 @@ t.test('too many args', async t => {
     /libnpmdiff needs two arguments to compare/,
     'should output diff against cwd files'
   )
+})
+
+t.test('folder in node_modules', async t => {
+  const path = t.testdir({
+    node_modules: {
+      a: {
+        'package.json': json({
+          name: 'a',
+          version: '1.0.0',
+          scripts: {
+            prepare: `${process.execPath} prepare.js`,
+          },
+        }),
+        'prepare.js': 'throw new Error("ERR")',
+        node_modules: {
+          b: {
+            'package.json': json({
+              name: 'b',
+              version: '2.0.0',
+              scripts: {
+                prepare: `${process.execPath} prepare.js`,
+              },
+            }),
+            'prepare.js': 'throw new Error("ERR")',
+          },
+        },
+      },
+    },
+    packages: {
+      a: {
+        'package.json': json({
+          name: 'a',
+          version: '1.0.1',
+          scripts: {
+            prepare: `${process.execPath} prepare.js`,
+          },
+        }),
+        'prepare.js': '',
+      },
+      b: {
+        'package.json': json({
+          name: 'b',
+          version: '2.0.1',
+          scripts: {
+            prepare: `${process.execPath} prepare.js`,
+          },
+        }),
+        'prepare.js': '',
+      },
+    },
+    'package.json': json({
+      name: 'my-project',
+      version: '1.0.0',
+    }),
+  })
+
+  t.test('top-level, absolute path', async t => {
+    t.resolveMatchSnapshot(diff([
+      `file:${resolve(path, 'node_modules/a')}`,
+      `file:${resolve(path, 'packages/a')}`,
+    ], { where: path }), 'should output expected diff')
+  })
+  t.test('top-level, relative path', async t => {
+    const _cwd = process.cwd()
+    process.chdir(path)
+    t.teardown(() => {
+      process.chdir(_cwd)
+    })
+
+    t.resolveMatchSnapshot(diff([
+      'file:./node_modules/a',
+      'file:./packages/a',
+    ], { where: path }), 'should output expected diff')
+  })
+  t.test('nested, absolute path', async t => {
+    t.resolveMatchSnapshot(diff([
+      `file:${resolve(path, 'node_modules/a/node_modules/b')}`,
+      `file:${resolve(path, 'packages/b')}`,
+    ], { where: path}), 'should output expected diff')
+  })
+  t.test('nested, relative path', async t => {
+    const _cwd = process.cwd()
+    process.chdir(path)
+    t.teardown(() => {
+      process.chdir(_cwd)
+    })
+
+    t.resolveMatchSnapshot(diff([
+      'file:./node_modules/a/node_modules/b',
+      'file:./packages/b',
+    ], { where: path }), 'should output expected diff')
+  })
 })

--- a/test/tarball.js
+++ b/test/tarball.js
@@ -1,0 +1,96 @@
+const { resolve } = require('path')
+
+const t = require('tap')
+const tar = require('tar')
+const pacote = require('pacote')
+pacote.tarball = () => {
+  throw new Error('Failed to detect node_modules tarball')
+}
+
+const tarball = require('../lib/tarball.js')
+
+const json = (obj) => `${JSON.stringify(obj, null, 2)}\n`
+
+t.test('returns a tarball from node_modules', t => {
+  t.plan(2)
+
+  const path = t.testdir({
+    node_modules: {
+      a: {
+        'package.json': json({
+          name: 'a',
+          version: '1.0.0',
+          bin: { a: 'index.js' },
+        }),
+        'index.js': '',
+      },
+    },
+  })
+
+  const _cwd = process.cwd()
+  process.chdir(path)
+  t.teardown(() => {
+    process.chdir(_cwd)
+  })
+
+  tarball({ bin: { a: 'index.js' }, _resolved: resolve(path, 'node_modules/a') }, { where: path })
+    .then(res => {
+      tar.list({
+        filter: path => {
+          t.match(
+            path,
+            /package.json|index.js/,
+            'should return tarball with expected files'
+          )
+        },
+      })
+        .on('error', e => {
+          throw e
+        })
+        .end(res)
+    })
+})
+
+t.test('node_modules folder within a linked dir', async t => {
+  const path = t.testdir({
+    node_modules: {
+      a: t.fixture('symlink', '../packages/a'),
+    },
+    packages: {
+      a: {
+        node_modules: {
+          b: {
+            'package.json': json({
+              name: 'a',
+              version: '1.0.0',
+            }),
+          },
+        },
+      },
+    },
+  })
+
+  const link = await tarball({ _resolved: resolve(path, 'node_modules/a/node_modules/b') }, {})
+  t.ok(link, 'should retrieve tarball from reading link')
+
+  const target = await tarball({ _resolved: resolve(path, 'packages/a/node_modules/b') }, {})
+  t.ok(target, 'should retrieve tarball from reading target')
+})
+
+t.test('pkg not in a node_modules folder', async t => {
+  const path = t.testdir({
+    packages: {
+      a: {
+        'package.json': json({
+          name: 'a',
+          version: '1.0.0',
+        }),
+      },
+    },
+  })
+
+  t.throws(
+    () => tarball({ _resolved: resolve(path, 'packages/a') }, {}),
+    'should call regular pacote.tarball method instead'
+  )
+})


### PR DESCRIPTION
When reading files from dependencies installed under a node_modules
folder we should skip some of the extra steps from pacote.tarball,
namely running the prepare script and the full packlist logic. Given
that the files are already installed on disk we may use
@npmcli/installed-package-contents to read them and just create a simple
tarball from it.

